### PR TITLE
added ability to name the 'spreadsheet' list via 'table' option

### DIFF
--- a/csv_to_facts.py
+++ b/csv_to_facts.py
@@ -14,13 +14,13 @@ DOCUMENTATION = '''
 ---
 module: csv_to_facts.py
 author: Joel W. King, World Wide Technology
-version_added: "1.0"
-short_description: Read a CSV file and output Ansible facts 
+version_added: "1.01"
+short_description: Read a CSV file and output Ansible facts
 description:
     - Read the CSV file specified and output Ansible facts in the form of a list with each
       element in the list as a dictionary using the column header as the key and the contents
       of the cell as the value.
- 
+
 requirements:
     - None
 
@@ -30,7 +30,13 @@ options:
             - The CSV formatted input file
         required: true
 
-    
+    table:
+        description:
+            - The name of the list created
+            - defaults to 'spreadsheet'
+        required: false
+
+
 '''
 
 EXAMPLES = '''
@@ -38,6 +44,7 @@ EXAMPLES = '''
     Running the module
 
       ansible  localhost  -m csv_to_facts -a "src=/tmp/TonyA.csv"
+      ansible  localhost  -m csv_to_facts -a "src=/tmp/TonyA.csv table=my_data"
 
     In a role configuration, given a group and host entry
 
@@ -64,15 +71,16 @@ import csv
 # read_csv_dict
 # ---------------------------------------------------------------------------
 
-def read_csv_dict(input_file):
+def read_csv_dict(input_file, table_name):
     "Read the CSV file and return as Ansible factsn"
     result = {"ansible_facts":{}}
-    spreadsheet = {"spreadsheet":[]}
+    spreadsheet = {table_name:[]}
+
     try:
         with open(input_file) as csvfile:
             reader = csv.DictReader(csvfile, delimiter=',', quotechar='"')
             for row in reader:
-                spreadsheet["spreadsheet"].append(row)
+                 spreadsheet[table_name].append(row)
     except IOError:
         return (1, "IOError on input file:%s" % input_file)
 
@@ -88,12 +96,14 @@ def read_csv_dict(input_file):
 def main():
     " "
     module = AnsibleModule(argument_spec = dict(
-             src = dict(required=True)
+             src = dict(required=True, type='str'),
+             table = dict(default='spreadsheet', required=False, type='str')
              ),
              check_invalid_arguments=False,
              add_file_common_args=True)
 
-    code, response = read_csv_dict(module.params["src"])
+    code, response = read_csv_dict(module.params["src"],
+                                   module.params["table"])
     if code == 1:
         module.fail_json(msg=response)
     else:


### PR DESCRIPTION
I found I'd like to be able to name the 'spreadsheet' list.  I wanted to call csv_to_facts module for more than a single type of table in a role and decrease confusion.  Adding the ability to name my tables helps the readability of my plays.  Example:
- name: import vlans csv
  csv_to_facts:
    src: "vlans.csv"
    table: vlans
- name: import interfaces csv
  csv_to_facts:
    src: "interfaces.csv"
    table: interfaces
